### PR TITLE
CondaKernelSpecManager (aka, reinterpretation of syncer)

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -7,12 +7,12 @@ platform:
 engine:
   - python=2.7
   - python=3.4
+  - python=3.5
 
 install:
-  - conda build conda.recipe
-  - conda install nb_conda_kernels --use-local -c anaconda-notebook
+  - conda config --add channels anaconda-notebook
 
 script:
-  - conda build --no-test ./conda.recipe/ -c anaconda-notebook
+  - conda build --quiet conda.recipe
 
 build_targets: conda

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,18 @@
+package: nb_conda_kernels
+
+platform:
+  - linux-64
+  - osx-64
+
+engine:
+  - python=2.7
+  - python=3.4
+
+install:
+  - conda build conda.recipe
+  - conda install nb_conda_kernels --use-local -c anaconda-notebook
+
+script:
+  - conda build --no-test ./conda.recipe/ -c anaconda-notebook
+
+build_targets: conda

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: nb_conda_kernels
+  version: "0.1.0"
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', '0') }}
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - nbwrapper
+
+source:
+  path: ../
+
+about:
+  home: https://github.com/Anaconda-Server/anaconda-notebook
+  license: TBD

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,6 +12,8 @@ requirements:
   run:
     - python
     - nbwrapper
+    # Beta solving a py2 bug on last traitlets
+    - traitlets ==4.1.0b1
 
 source:
   path: ../

--- a/conda.recipe/post-link.bat
+++ b/conda.recipe/post-link.bat
@@ -1,1 +1,1 @@
-"%PREFIX%/bin/python" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"
+"%PREFIX%\bin\python" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"

--- a/conda.recipe/post-link.bat
+++ b/conda.recipe/post-link.bat
@@ -1,0 +1,1 @@
+"%PREFIX%/bin/python" -m nb_conda_kernels.install --enable --prefix="%PREFIX%"

--- a/conda.recipe/post-link.sh
+++ b/conda.recipe/post-link.sh
@@ -1,0 +1,1 @@
+"${PREFIX}/bin/python" -m nb_conda_kernels.install --enable --prefix="${PREFIX}"

--- a/conda.recipe/pre-unlink.bat
+++ b/conda.recipe/pre-unlink.bat
@@ -1,1 +1,1 @@
-"%PREFIX%/bin/python" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"
+"%PREFIX%\bin\python" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"

--- a/conda.recipe/pre-unlink.bat
+++ b/conda.recipe/pre-unlink.bat
@@ -1,0 +1,1 @@
+"%PREFIX%/bin/python" -m nb_conda_kernels.install --disable --prefix="%PREFIX%"

--- a/conda.recipe/pre-unlink.sh
+++ b/conda.recipe/pre-unlink.sh
@@ -1,0 +1,1 @@
+"${PREFIX}/bin/python" -m nb_conda_kernels.install --disable --prefix="${PREFIX}"

--- a/nb_conda_kernels/__init__.py
+++ b/nb_conda_kernels/__init__.py
@@ -1,0 +1,2 @@
+from ._version import version_info, __version__
+from .nb_conda_kernels import CondaKernelSpecManager

--- a/nb_conda_kernels/_version.py
+++ b/nb_conda_kernels/_version.py
@@ -1,0 +1,2 @@
+version_info = (0, 1, 0)
+__version__ = '.'.join(map(str, version_info))

--- a/nb_conda_kernels/install.py
+++ b/nb_conda_kernels/install.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) - Continuum Analytics
+
+import argparse
+import os
+from os.path import exists, join
+from pprint import pprint
+
+from jupyter_core.paths import jupyter_config_dir
+
+def install(enable=False, disable=False, prefix=None):
+    """Install the nb_conda_kernels config piece.
+
+    Parameters
+    ----------
+    enable: bool
+        Enable the nb_conda_kernels on every notebook launch
+    disable: bool
+        Disable nb_conda_kernels on every notebook launch
+    """
+    from notebook.services.config import ConfigManager
+
+    if enable:
+        if prefix is not None:
+            path = join(prefix, "etc", "jupyter")
+            if not exists(path):
+                print("Making directory", path)
+                os.makedirs(path)
+        else:
+            path = jupyter_config_dir()
+
+        cm = ConfigManager(config_dir=path)
+        print("Enabling nb_conda_kernels in", cm.config_dir)
+        cfg = cm.get("jupyter_notebook_config")
+        print("Existing config...")
+        pprint(cfg)
+
+        notebook_app = (cfg.setdefault("NotebookApp", {}))
+        if "kernel_spec_manager_class" not in notebook_app:
+            cfg["NotebookApp"]["kernel_spec_manager_class"] = "nb_conda_kernels.CondaKernelSpecManager"
+
+        cm.update("jupyter_notebook_config", cfg)
+        print("New config...")
+        pprint(cm.get("jupyter_notebook_config"))
+
+    if disable:
+        if prefix is not None:
+            path = join(prefix, "etc", "jupyter")
+        else:
+            path = jupyter_config_dir()
+
+        cm = ConfigManager(config_dir=path)
+        print("Disabling nb_conda_kernels in", cm.config_dir)
+        cfg = cm.get("jupyter_notebook_config")
+        print("Existing config...")
+        pprint(cfg)
+
+        kernel_spec_manager = cfg["NotebookApp"]["kernel_spec_manager_class"]
+
+        if "nb_conda_kernels.CondaKernelSpecManager" == kernel_spec_manager:
+            cfg["NotebookApp"].pop("kernel_spec_manager_class")
+
+        cm.set("jupyter_notebook_config", cfg)
+        print("New config...")
+        pprint(cm.get("jupyter_notebook_config"))
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(
+        description="Installs nbextension")
+    parser.add_argument(
+        "-e", "--enable",
+        help="Automatically load nb_conda_kernels on notebook launch",
+        action="store_true")
+    parser.add_argument(
+        "-d", "--disable",
+        help="Remove nb_conda_kernels from config on notebook launch",
+        action="store_true")
+    parser.add_argument(
+        "-p", "--prefix",
+        help="prefix where to load nb_conda_kernels config",
+        action="store")
+
+    install(**parser.parse_args().__dict__)

--- a/nb_conda_kernels/nb_conda_kernels.py
+++ b/nb_conda_kernels/nb_conda_kernels.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+import json
+import subprocess
+import sys
+
+from os.path import exists, join, split
+
+from jupyter_client.kernelspec import KernelSpecManager, KernelSpec, NoSuchKernel
+
+class CondaKernelSpecManager(KernelSpecManager):
+    """A custom KernelSpecManager able to search for conda environments and
+    create kernelspecs for them.
+    """
+    # at /tree all the kernelspec are loaded... we need to get conda_info at
+    # the very beginning to avoid a large loading time
+    first_read = True
+
+    def __init__(self, **kwargs):
+        super(CondaKernelSpecManager, self).__init__(**kwargs)
+        self.conda_info = self._conda_info()
+
+    def _conda_info(self):
+        "Get and parse the whole conda information"
+        p = subprocess.check_output(["conda", "info", "--json"]).decode("utf-8")
+        conda_info = json.loads(p)
+
+        return conda_info
+
+    def _python_executable(self):
+        """Find the python executable for each env where jupyter is installed.
+
+        Returns a dict with the envs names as keys and the paths to the python
+        exectuable in each env as value if jupyter is installed in that env.
+        """
+        # First time we load the conda info from the __init__
+        if self.first_read:
+            conda_info = self.conda_info
+            first_read = False
+        # but after that, we check if there is not a new env
+        else:
+            update_conda_info = self._conda_info()
+            if update_conda_info["envs"] == self.conda_info["envs"]:
+                conda_info = self.conda_info
+            else:
+                conda_info = update_conda_info
+
+        # play safe with windows
+        if sys.platform.startswith('win'):
+            python = join("Scripts", "python")
+            jupyter = join("Scripts", "jupyter")
+        else:
+            python = join("bin", "python")
+            jupyter = join("bin", "jupyter")
+
+        # python_exe = {name_env: python_path_env}
+        python_exe = {split(base)[1]: join(base, python)
+                      for base in conda_info["envs"]
+                      if exists(join(base, jupyter))}
+
+        # We also add the root prefix into the soup
+        root_prefix = join(conda_info["root_prefix"], jupyter)
+        if exists(root_prefix):
+            python_exe.update({"root": join(conda_info["root_prefix"], python)})
+
+        return python_exe
+
+    def _conda_kspecs(self):
+        "Create a kernelspec for each of the envs where jupyter is installed"
+        kspecs = {}
+        for name, executable in self._python_executable().items():
+            kspec =  {"argv": [executable, "-m", "ipykernel", "-f", "{connection_file}"],
+                      "display_name": name,
+                      "env": {}}
+            kspecs.update({name: KernelSpec(**kspec)})
+
+        return kspecs
+
+    def find_kernel_specs(self):
+        """Returns a dict mapping kernel names to resource directories.
+
+        The update process also add the resource dir for the conda environments.
+        """
+        kspecs = super(CondaKernelSpecManager, self).find_kernel_specs()
+
+        # remove native kernels because it is provided by the env name
+        if "python3" in kspecs:
+            kspecs.pop("python3")
+        elif "python2" in kspecs:
+            kspecs.pop("python2")
+
+        # add conda envs kernelspecs
+        kspecs.update(self._python_executable())
+
+        return kspecs
+
+    def get_kernel_spec(self, kernel_name):
+        """Returns a :class:`KernelSpec` instance for the given kernel_name.
+
+        Additionally, conda kernelspecs are generated on the fly accordingly
+        with the detected envitonments.
+        Raises :exc:`NoSuchKernel` if the given kernel name is not found.
+        """
+        if kernel_name in self._conda_kspecs():
+            return self._conda_kspecs()[kernel_name]
+        else:
+            return super(CondaKernelSpecManager, self).get_kernel_spec(kernel_name)

--- a/nb_conda_kernels/nb_conda_kernels.py
+++ b/nb_conda_kernels/nb_conda_kernels.py
@@ -6,7 +6,7 @@ import sys
 
 from os.path import exists, join, split
 
-from jupyter_client.kernelspec import KernelSpecManager, KernelSpec, NoSuchKernel
+from jupyter_client.kernelspec import KernelSpecManager, KernelSpec
 
 class CondaKernelSpecManager(KernelSpecManager):
     """A custom KernelSpecManager able to search for conda environments and
@@ -99,7 +99,6 @@ class CondaKernelSpecManager(KernelSpecManager):
 
         Additionally, conda kernelspecs are generated on the fly accordingly
         with the detected envitonments.
-        Raises :exc:`NoSuchKernel` if the given kernel name is not found.
         """
         if kernel_name in self._conda_kspecs():
             return self._conda_kspecs()[kernel_name]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) - Continuum Analytics
+
+from __future__ import print_function
+
+# the name of the project
+name = 'nb_conda_kernels'
+
+#-----------------------------------------------------------------------------
+# Minimal Python version sanity check
+#-----------------------------------------------------------------------------
+
+import sys
+
+v = sys.version_info
+if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,4)):
+    error = "ERROR: %s requires Python version 2.7 or 3.4 or above." % name
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
+#-----------------------------------------------------------------------------
+# Main
+#-----------------------------------------------------------------------------
+
+import os
+from glob import glob
+
+from distutils.core import setup
+
+pjoin = os.path.join
+here = os.path.abspath(os.path.dirname(__file__))
+pkg_root = pjoin(here, name)
+
+packages = []
+for d, _, _ in os.walk(pjoin(here, name)):
+    if os.path.exists(pjoin(d, '__init__.py')):
+        packages.append(d[len(here)+1:].replace(os.path.sep, '.'))
+
+version_ns = {}
+with open(pjoin(here, name, '_version.py')) as f:
+    exec(f.read(), {}, version_ns)
+
+setup_args = dict(
+    name            = name,
+    version         = version_ns['__version__'],
+    packages        = packages,
+    #description     = "",
+    #long_description= """
+    #""",
+    #author          = '',
+    #author_email    = '',
+    #url             = '',
+    #license         = '',
+    platforms       = "Linux, Mac OS X, Windows",
+    #keywords        = [],
+    #classifiers     = [],
+    #cmdclass        = []
+)
+
+if 'develop' in sys.argv or any(bdist in sys.argv for bdist in ['bdist_wheel', 'bdist_egg']):
+    import setuptools
+
+setuptools_args = {}
+
+REQUIRES = [
+    "nbwrapper",
+]
+
+install_requires = setuptools_args['install_requires'] = REQUIRES
+
+if 'setuptools' in sys.modules:
+    setup_args.update(setuptools_args)
+
+if __name__ == '__main__':
+    setup(**setup_args)


### PR DESCRIPTION
Create a custom KernelSpecManager able to read conda envs and create kernelspecs for them. Also all the packaging.

This is tied to this PR https://github.com/Anaconda-Server/anaconda-notebook/pull/107, which removes leftovers.